### PR TITLE
Reduced dependencies from symfony/symfony to symfony/dependency-injection and symfony/config.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     },
     "require": {
         "php": ">=7.0",
-        "symfony/symfony": "^3.2"
+        "symfony/dependency-injection": "^3.2",
+        "symfony/config": "^3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
We don't need symfony/symfony, but symfony/dependency-injection and symfony/config.

Addresses #7.