### PR TITLE
Add extension support with the `extension()` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,3 +358,26 @@ This is the same as:
 imports:
     - { resource: services/mailer.yml }
 ```
+
+## Extensions
+
+Extensions (like the framework configuration for example) can be configured using the `extension()` function helper:
+
+```php
+use function Fluent\extension;
+
+return [
+    extension('framework', [
+        'http_method_override' => true,
+        'trusted_proxies' => ['192.0.0.1', '10.0.0.0/8'],
+    ]),
+];
+```
+
+This is the same as:
+
+```yaml
+framework:
+    http_method_override: true
+    trusted_proxies: [192.0.0.1, 10.0.0.0/8]
+```

--- a/src/DefinitionHelper/ExtensionConfiguration.php
+++ b/src/DefinitionHelper/ExtensionConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace Fluent\DefinitionHelper;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class ExtensionConfiguration implements DefinitionHelper
+{
+    /**
+     * @var string
+     */
+    private $extensionName;
+
+    /**
+     * @var array
+     */
+    private $configuration;
+
+    public function __construct(string $extensionName, array $configuration)
+    {
+        $this->extensionName = $extensionName;
+        $this->configuration = $configuration;
+    }
+
+    public function register(string $entryId, ContainerBuilder $container)
+    {
+        $container->loadFromExtension($this->extensionName, $this->configuration);
+    }
+}

--- a/src/PhpConfigLoader.php
+++ b/src/PhpConfigLoader.php
@@ -40,7 +40,7 @@ class PhpConfigLoader extends Loader
             }
 
             // Register the definition in the container
-            $definitionHelper->register($entryId, $this->container);
+            $definitionHelper->register((string) $entryId, $this->container);
         }
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -5,6 +5,7 @@ namespace Fluent;
 
 use Fluent\DefinitionHelper\AliasDefinitionHelper;
 use Fluent\DefinitionHelper\CreateDefinitionHelper;
+use Fluent\DefinitionHelper\ExtensionConfiguration;
 use Fluent\DefinitionHelper\FactoryDefinitionHelper;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -66,6 +67,22 @@ if (!function_exists('Fluent\create')) {
     function autowire(string $className = null) : CreateDefinitionHelper
     {
         return new CreateDefinitionHelper($className, true);
+    }
+
+    /**
+     * Helps configuring an extension.
+     *
+     * Example:
+     *
+     *     return [
+     *         extension('framework', [
+     *             'trusted_proxies' => ['192.0.0.1', '10.0.0.0/8'],
+     *         ]),
+     *     ];
+     */
+    function extension(string $extensionName, array $config) : ExtensionConfiguration
+    {
+        return new ExtensionConfiguration($extensionName, $config);
     }
 
 }

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Fluent\Test;
+
+use function Fluent\extension;
+use Fluent\PhpConfigLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension as BaseExtension;
+
+/**
+ * Test extension() definitions.
+ */
+class ExtensionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function configures_an_extension()
+    {
+        // The container extension class
+        $fooExtension = new class() extends BaseExtension {
+            public function load(array $configs, ContainerBuilder $container)
+            {
+                $container->setParameter('magic_parameter', $configs[0]['bar']);
+            }
+            public function getAlias()
+            {
+                return 'foo';
+            }
+        };
+
+        $container = new ContainerBuilder;
+        $container->registerExtension($fooExtension);
+        (new PhpConfigLoader($container))->load([
+            extension('foo', [
+                'bar' => 'Hello world',
+            ]),
+        ]);
+        $container->compile(); // we must compile the container so that extensions are applied
+
+        self::assertEquals('Hello world', $container->getParameter('magic_parameter'));
+    }
+}


### PR DESCRIPTION
I've gone with the solution I described in https://github.com/mnapoli/fluent-symfony/issues/2#issuecomment-277528798 for example:

```php
use function Fluent\extension;

return [

    extension('framework', [
        'http_method_override' => true,
        'trusted_proxies' => ['192.0.0.1', '10.0.0.0/8'],
    ]),

];
```

In the future, some bundles could even provide a custom helper that could help configure it in a much stricter way, for example:

```php
return [

    framework()
        ->httpMethodOverride(true)
        ->trustedProxies(['192.0.0.1', '10.0.0.0/8']),

];
```

but that might be a bit of work to write. Maybe those classes could be autogenerated based on the `Configuration` tree, for example https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php#L51-L66 ? Anyway, that's just an idea.