### PR TITLE
Add support for "traditional" PHP config files

### DIFF
--- a/src/PhpConfigFileLoader.php
+++ b/src/PhpConfigFileLoader.php
@@ -30,6 +30,12 @@ class PhpConfigFileLoader extends FileLoader
 
     public function load($resource, $type = null)
     {
+        // The container and loader variables are exposed to the included file below
+        // This is done to support "traditional" PHP config files
+        // @see \Symfony\Component\DependencyInjection\Loader\PhpFileLoader
+        $container = $this->container;
+        $loader = $this;
+
         $path = $this->locator->locate($resource);
         $this->setCurrentDir(dirname($path));
         $this->container->addResource(new FileResource($path));
@@ -37,7 +43,8 @@ class PhpConfigFileLoader extends FileLoader
         $definitions = require $path;
 
         if (!is_array($definitions)) {
-            throw new \Exception(sprintf('The configuration file %s must return an array', $path));
+            // Support for traditional PHP config files
+            return;
         }
 
         // Process imports

--- a/tests/Fixtures/traditional-php-config.php
+++ b/tests/Fixtures/traditional-php-config.php
@@ -1,0 +1,3 @@
+<?php
+
+$container->setParameter('foo', 'bar');

--- a/tests/PhpConfigFileLoaderTest.php
+++ b/tests/PhpConfigFileLoaderTest.php
@@ -44,15 +44,24 @@ class PhpConfigFileLoaderTest extends TestCase
     }
 
     /**
+     * Tests that "traditional" PHP config files for Symfony are supported.
+     *
+     * Since the loader loads all `.php` files, it will replace and override completely
+     * the Symfony\Component\DependencyInjection\Loader\PhpFileLoader loader.
+     *
+     * As such, it must support files loaded by Symfony\Component\DependencyInjection\Loader\PhpFileLoader.
+     *
+     * @see \Symfony\Component\DependencyInjection\Loader\PhpFileLoader
+     *
      * @test
-     * @expectedException \Exception
-     * @expectedExceptionMessageRegExp #The configuration file .+/tests/Fixtures/empty-file.php must return an array#
      */
-    public function verifies_that_config_files_return_an_array()
+    public function supports_traditional_php_config_files()
     {
         $container = new ContainerBuilder;
         $loader = new PhpConfigFileLoader($container, new FileLocator);
 
-        $loader->load(__DIR__ . '/Fixtures/empty-file.php');
+        $loader->load(__DIR__ . '/Fixtures/traditional-php-config.php');
+
+        self::assertEquals('bar', $container->getParameter('foo'));
     }
 }


### PR DESCRIPTION
Since the loader loads all `.php` files, it will replace and override completely the `Symfony\Component\DependencyInjection\Loader\PhpFileLoader` loader.

As such, it must support files loaded by `Symfony\Component\DependencyInjection\Loader\PhpFileLoader` (to keep backward compatibility).

This need turned out necessary when trying to actually use the "fluent" config format in the Symfony standard edition.