### PR TITLE
Missing use statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ services:
 Services can be injected using the `get()` function helper:
 
 ```php
+use function Fluent\get;
+
 return [
     'newsletter_manager' => create(NewsletterManager::class)
         ->arguments(get('mailer')),


### PR DESCRIPTION
In the example, the `use function Fluent\get;` is missing.
This PR just add it for a better understanding.