### PR TITLE
Compile the container in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Services can be created by [factories](https://symfony.com/doc/current/service_c
 use function Fluent\factory;
 
 return [
-    'newsletter_manager' => factory([NewsletterManager::class, 'create'])
+    'newsletter_manager' => factory([NewsletterManager::class, 'create'], NewsletterManager::class)
         ->arguments('foo', 'bar'),
 ];
 ```
@@ -489,7 +489,19 @@ This is the same as:
 services:
     newsletter_manager:
         factory: ['AppBundle\Email\NewsletterManager', 'create']
+        class: 'AppBundle\Email\NewsletterManager'
         arguments: ['foo', 'bar']
+```
+
+When using the class name as service ID, you don't have to explicitly state the class name of the service:
+
+```php
+return [
+    // you can write:
+    NewsletterManager::class => factory([NewsletterManager::class, 'create']),
+    // instead of:
+    NewsletterManager::class => factory([NewsletterManager::class, 'create'], NewsletterManager::class),
+];
 ```
 
 ## Aliases

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
             "src/functions.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Fluent\\Test\\": "tests"
+        }
+    },
     "require": {
         "php": ">=7.0",
         "symfony/dependency-injection": "^3.2",

--- a/src/DefinitionHelper/FactoryDefinitionHelper.php
+++ b/src/DefinitionHelper/FactoryDefinitionHelper.php
@@ -20,15 +20,21 @@ class FactoryDefinitionHelper implements DefinitionHelper
 
     /**
      * @param string|array $factory A PHP function or an array containing a class/Reference and a method to call
+     * @param string|null $className Class name of the object.
+     *                               If null, the name of the entry (in the container) will be used as class name.
      */
-    public function __construct($factory)
+    public function __construct($factory, string $className = null)
     {
-        $this->definition = new Definition();
+        $this->definition = new Definition($className);
         $this->definition->setFactory($factory);
     }
 
     public function register(string $entryId, ContainerBuilder $container)
     {
+        if ($this->definition->getClass() === null) {
+            $this->definition->setClass($entryId);
+        }
+
         $container->setDefinition($entryId, $this->definition);
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -42,10 +42,12 @@ if (!function_exists('Fluent\create')) {
      * Create a service using a factory
      *
      * @param string|array $factory A PHP function or an array containing a class/Reference and a method to call
+     * @param string|null $className Class name of the object.
+     *                               If null, the name of the entry (in the container) will be used as class name.
      */
-    function factory($factory) : FactoryDefinitionHelper
+    function factory($factory, string $className = null) : FactoryDefinitionHelper
     {
-        return new FactoryDefinitionHelper($factory);
+        return new FactoryDefinitionHelper($factory, $className);
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,7 +7,6 @@ use Fluent\DefinitionHelper\AliasDefinitionHelper;
 use Fluent\DefinitionHelper\CreateDefinitionHelper;
 use Fluent\DefinitionHelper\ExtensionConfiguration;
 use Fluent\DefinitionHelper\FactoryDefinitionHelper;
-use Fluent\Reference;
 
 // This `if` avoids errors if importing the file twice
 if (!function_exists('Fluent\create')) {

--- a/tests/AliasTest.php
+++ b/tests/AliasTest.php
@@ -2,40 +2,33 @@
 
 namespace Fluent\Test;
 
-use Fluent\PhpConfigLoader;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use function Fluent\alias;
 use function Fluent\create;
 
 /**
  * Test alias() definitions.
  */
-class AliasTest extends TestCase
+class AliasTest extends BaseContainerTest
 {
-    public function test_alias_service()
+    /** @test */
+    public function services_can_be_aliased()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => alias('bar'),
             'bar' => create('stdClass'),
         ]);
         self::assertInstanceOf('stdClass', $container->get('foo'));
     }
 
-    /**
-     * @test
-     */
-    public function alias_can_be_marked_as_private()
+    /** @test */
+    public function aliases_can_be_marked_as_private()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
-            'foo' => alias('bar')
+        $container = $this->createContainerWithConfig([
+            'foo' => alias('bar'),
+            'bar' => create('stdClass')
                 ->private(),
-            'bar' => create('stdClass'),
         ]);
-
-        self::assertFalse($container->getAlias('foo')->isPublic());
         self::assertInstanceOf('stdClass', $container->get('foo'));
+        self::assertFalse($container->has('bar'));
     }
 }

--- a/tests/AutowireTest.php
+++ b/tests/AutowireTest.php
@@ -5,18 +5,15 @@ namespace Fluent\Test;
 use function Fluent\autowire;
 use function Fluent\create;
 use Fluent\PhpConfigLoader;
-use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Test autowire() definitions.
  */
-class AutowireTest extends TestCase
+class AutowireTest extends BaseContainerTest
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function service_can_be_created_as_autowired()
     {
         $autowiredClass = new class(new stdClass) {
@@ -27,19 +24,15 @@ class AutowireTest extends TestCase
         };
         $autowiredClassName = get_class($autowiredClass);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             stdClass::class => create(stdClass::class),
-            'foo'           => autowire($autowiredClassName),
+            'foo' => autowire($autowiredClassName),
         ]);
-        $container->compile();
 
         self::assertInstanceOf(stdClass::class, $container->get('foo')->argument);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function service_can_be_created_as_autowired_without_class_name()
     {
         $autowiredClass = new class(new stdClass) {
@@ -50,19 +43,15 @@ class AutowireTest extends TestCase
         };
         $autowiredClassName = get_class($autowiredClass);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
-            stdClass::class     => create(stdClass::class),
+        $container = $this->createContainerWithConfig([
+            stdClass::class => create(stdClass::class),
             $autowiredClassName => autowire(),
         ]);
-        $container->compile();
 
         self::assertInstanceOf(stdClass::class, $container->get($autowiredClassName)->argument);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function autowired_services_can_be_tagged()
     {
         $container = new ContainerBuilder;
@@ -70,13 +59,13 @@ class AutowireTest extends TestCase
             'bar' => autowire('stdClass')
                 ->tag('foo'),
         ]);
+        $container->compile();
+
         self::assertTrue($container->findDefinition('bar')->hasTag('foo'));
         self::assertArrayHasKey('bar', $container->findTaggedServiceIds('foo'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function autowired_services_can_be_tagged_with_attributes()
     {
         $container = new ContainerBuilder;
@@ -84,14 +73,14 @@ class AutowireTest extends TestCase
             'bar' => autowire('stdClass')
                 ->tag('foo', ['alias' => 'baz']),
         ]);
+        $container->compile();
+
         $tagged = $container->findTaggedServiceIds('foo');
         self::assertArrayHasKey('alias', $tagged['bar'][0]);
         self::assertEquals('baz', $tagged['bar'][0]['alias']);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function autowired_services_can_be_tagged_multiple_times()
     {
         $container = new ContainerBuilder;
@@ -100,6 +89,8 @@ class AutowireTest extends TestCase
                 ->tag('foo')
                 ->tag('baz'),
         ]);
+        $container->compile();
+
         self::assertTrue($container->findDefinition('bar')->hasTag('foo'));
         self::assertTrue($container->findDefinition('bar')->hasTag('baz'));
     }

--- a/tests/BaseContainerTest.php
+++ b/tests/BaseContainerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Fluent\Test;
+
+use Fluent\PhpConfigLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+abstract class BaseContainerTest extends TestCase
+{
+    public function createContainerWithConfig(array $config) : ContainerBuilder
+    {
+        $container = new ContainerBuilder;
+        (new PhpConfigLoader($container))->load($config);
+
+        // The container must always be compiled to ensure we test in realistic conditions
+        // If we don't do that several edge cases are not covered
+        $container->compile();
+
+        return $container;
+    }
+}

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -4,19 +4,15 @@ namespace Fluent\Test;
 
 use function Fluent\create;
 use function Fluent\get;
-use Fluent\PhpConfigLoader;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Test create() definitions.
  */
-class CreateTest extends TestCase
+class CreateTest extends BaseContainerTest
 {
     public function test_create_with_class_name_provided()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => create('stdClass'),
         ]);
         self::assertInstanceOf('stdClass', $container->get('foo'));
@@ -24,8 +20,7 @@ class CreateTest extends TestCase
 
     public function test_create_with_class_name_as_array_key()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'stdClass' => create(),
         ]);
         self::assertInstanceOf('stdClass', $container->get('stdClass'));
@@ -41,8 +36,7 @@ class CreateTest extends TestCase
         };
         $className = get_class($fixture);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => create($className)
                 ->arguments('abc', 'def'),
         ]);
@@ -56,8 +50,7 @@ class CreateTest extends TestCase
         };
         $className = get_class($fixture);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => create($className)
                 ->property('foo', 'bar'),
         ]);
@@ -74,8 +67,7 @@ class CreateTest extends TestCase
         };
         $className = get_class($fixture);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => create($className)
                 ->method('setSomething', 'abc', 'def'),
         ]);
@@ -93,8 +85,7 @@ class CreateTest extends TestCase
         };
         $className = get_class($fixture);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             $className => create()
                 ->method('increment')
                 ->method('increment'),
@@ -104,9 +95,7 @@ class CreateTest extends TestCase
         self::assertEquals(2, $class->count);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_injected()
     {
         $fixture = new class(null) {
@@ -117,8 +106,7 @@ class CreateTest extends TestCase
         };
         $className = get_class($fixture);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => create($className)
                 ->arguments(get('stdClass')),
             'stdClass' => create(),
@@ -126,9 +114,7 @@ class CreateTest extends TestCase
         self::assertInstanceOf('stdClass', $container->get('foo')->argument);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function missing_services_can_be_injected_with_null_value()
     {
         $fixture = new class(null) {
@@ -138,17 +124,15 @@ class CreateTest extends TestCase
             }
         };
         $className = get_class($fixture);
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+
+        $container = $this->createContainerWithConfig([
             'foo' => create($className)
                 ->arguments(get('Bar')->nullIfMissing())
         ]);
         self::assertNull($container->get('foo')->argument);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function missing_services_can_be_injected_in_method_with_no_method_call()
     {
         $fixture = new class() {
@@ -159,17 +143,15 @@ class CreateTest extends TestCase
             }
         };
         $className = get_class($fixture);
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+
+        $container = $this->createContainerWithConfig([
             'foo' => create($className)
                 ->method('setArgument', get('Bar')->ignoreIfMissing())
         ]);
         self::assertEquals(3, $container->get('foo')->argument);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function parameters_can_be_injected()
     {
         $fixture = new class(null) {
@@ -180,8 +162,7 @@ class CreateTest extends TestCase
         };
         $className = get_class($fixture);
 
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => create($className)
                 ->arguments('%abc%'),
             'abc' => 'def',
@@ -189,13 +170,10 @@ class CreateTest extends TestCase
         self::assertEquals('def', $container->get('foo')->argument);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_tagged()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'bar' => create('stdClass')
                 ->tag('foo'),
         ]);
@@ -203,13 +181,10 @@ class CreateTest extends TestCase
         self::assertArrayHasKey('bar', $container->findTaggedServiceIds('foo'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_tagged_with_attributes()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'bar' => create('stdClass')
                 ->tag('foo', ['alias' => 'baz']),
         ]);
@@ -218,13 +193,10 @@ class CreateTest extends TestCase
         self::assertEquals('baz', $tagged['bar'][0]['alias']);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_tagged_multiple_times()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'bar' => create('stdClass')
                 ->tag('foo')
                 ->tag('baz'),
@@ -233,52 +205,40 @@ class CreateTest extends TestCase
         self::assertTrue($container->findDefinition('bar')->hasTag('baz'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_marked_as_private()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'bar' => create('stdClass')
                 ->private()
         ]);
-        self::assertFalse($container->findDefinition('bar')->isPublic());
+        self::assertFalse($container->has('bar'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_marked_as_unshared()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'bar' => create('stdClass')
                 ->unshared()
         ]);
         self::assertFalse($container->get('bar') === $container->get('bar'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_deprecated()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'bar' => create('stdClass')
                 ->deprecate()
         ]);
         self::assertTrue($container->findDefinition('bar')->isDeprecated());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_deprecated_providing_a_template_message()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'bar' => create('stdClass')
                 ->deprecate('The "%service_id%" service is deprecated.')
         ]);

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -13,9 +13,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension as BaseExtension;
  */
 class ExtensionTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function configures_an_extension()
     {
         // The container extension class

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -5,34 +5,25 @@ namespace Fluent\Test;
 use function Fluent\create;
 use function Fluent\factory;
 use function Fluent\get;
-use Fluent\PhpConfigLoader;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Test factory() definitions.
  */
-class FactoryTest extends TestCase
+class FactoryTest extends BaseContainerTest
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function create_a_service_using_a_factory()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => factory([self::class, 'foo']),
         ]);
         self::assertInstanceOf('stdClass', $container->get('foo'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function arguments_can_be_passed_to_the_factory()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => factory([self::class, 'bar'])
                 ->arguments('abc', 'def'),
         ]);
@@ -40,13 +31,10 @@ class FactoryTest extends TestCase
         self::assertEquals('def', $container->get('foo')->arg2);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function services_can_be_injected_in_arguments()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => factory([self::class, 'bar'])
                 ->arguments(get('abc'), ''),
             'abc' => create('stdClass'),
@@ -54,13 +42,10 @@ class FactoryTest extends TestCase
         self::assertInstanceOf('stdClass', $container->get('foo')->arg1);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function parameters_can_be_injected_in_arguments()
     {
-        $container = new ContainerBuilder;
-        (new PhpConfigLoader($container))->load([
+        $container = $this->createContainerWithConfig([
             'foo' => factory([self::class, 'bar'])
                 ->arguments('%abc%', ''),
             'abc' => 'def',

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -12,12 +12,21 @@ use function Fluent\get;
 class FactoryTest extends BaseContainerTest
 {
     /** @test */
-    public function create_a_service_using_a_factory()
+    public function services_can_be_created_using_a_factory()
     {
         $container = $this->createContainerWithConfig([
-            'foo' => factory([self::class, 'foo']),
+            'foo' => factory([self::class, 'foo'], 'stdClass'),
         ]);
         self::assertInstanceOf('stdClass', $container->get('foo'));
+    }
+
+    /** @test */
+    public function the_class_name_can_be_guessed_from_the_service_id()
+    {
+        $container = $this->createContainerWithConfig([
+            'stdClass' => factory([self::class, 'foo']),
+        ]);
+        self::assertInstanceOf('stdClass', $container->get('stdClass'));
     }
 
     /** @test */


### PR DESCRIPTION
During the compilation, a lot of things happen (validation, etc.). We should execute those things (i.e. compile the container) in tests to ensure that we don't miss some edge cases. For example there is a bug in `factory` (see #28) that we missed because of that.

This commit refactors the tests so that the container is always compiled.

Due to this commit, tests are failing (i.e. it reproduces #28). Tests will be fixed in another commit for more readability.