### PR TITLE
Fix #28: factories must have a class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Services can be created by [factories](https://symfony.com/doc/current/service_c
 use function Fluent\factory;
 
 return [
-    'newsletter_manager' => factory([NewsletterManager::class, 'create'])
+    'newsletter_manager' => factory([NewsletterManager::class, 'create'], NewsletterManager::class)
         ->arguments('foo', 'bar'),
 ];
 ```
@@ -489,7 +489,19 @@ This is the same as:
 services:
     newsletter_manager:
         factory: ['AppBundle\Email\NewsletterManager', 'create']
+        class: 'AppBundle\Email\NewsletterManager'
         arguments: ['foo', 'bar']
+```
+
+When using the class name as service ID, you don't have to explicitly state the class name of the service:
+
+```php
+return [
+    // you can write:
+    NewsletterManager::class => factory([NewsletterManager::class, 'create']),
+    // instead of:
+    NewsletterManager::class => factory([NewsletterManager::class, 'create'], NewsletterManager::class),
+];
 ```
 
 ## Aliases

--- a/src/DefinitionHelper/FactoryDefinitionHelper.php
+++ b/src/DefinitionHelper/FactoryDefinitionHelper.php
@@ -20,15 +20,21 @@ class FactoryDefinitionHelper implements DefinitionHelper
 
     /**
      * @param string|array $factory A PHP function or an array containing a class/Reference and a method to call
+     * @param string|null $className Class name of the object.
+     *                               If null, the name of the entry (in the container) will be used as class name.
      */
-    public function __construct($factory)
+    public function __construct($factory, string $className = null)
     {
-        $this->definition = new Definition();
+        $this->definition = new Definition($className);
         $this->definition->setFactory($factory);
     }
 
     public function register(string $entryId, ContainerBuilder $container)
     {
+        if ($this->definition->getClass() === null) {
+            $this->definition->setClass($entryId);
+        }
+
         $container->setDefinition($entryId, $this->definition);
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -42,10 +42,12 @@ if (!function_exists('Fluent\create')) {
      * Create a service using a factory
      *
      * @param string|array $factory A PHP function or an array containing a class/Reference and a method to call
+     * @param string|null $className Class name of the object.
+     *                               If null, the name of the entry (in the container) will be used as class name.
      */
-    function factory($factory) : FactoryDefinitionHelper
+    function factory($factory, string $className = null) : FactoryDefinitionHelper
     {
-        return new FactoryDefinitionHelper($factory);
+        return new FactoryDefinitionHelper($factory, $className);
     }
 
     /**

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -12,12 +12,21 @@ use function Fluent\get;
 class FactoryTest extends BaseContainerTest
 {
     /** @test */
-    public function create_a_service_using_a_factory()
+    public function services_can_be_created_using_a_factory()
     {
         $container = $this->createContainerWithConfig([
-            'foo' => factory([self::class, 'foo']),
+            'foo' => factory([self::class, 'foo'], 'stdClass'),
         ]);
         self::assertInstanceOf('stdClass', $container->get('foo'));
+    }
+
+    /** @test */
+    public function the_class_name_can_be_guessed_from_the_service_id()
+    {
+        $container = $this->createContainerWithConfig([
+            'stdClass' => factory([self::class, 'foo']),
+        ]);
+        self::assertInstanceOf('stdClass', $container->get('stdClass'));
     }
 
     /** @test */


### PR DESCRIPTION
The factory has a new parameter:

```diff
 return [
-    'newsletter_manager' => factory([NewsletterManager::class, 'create'])
+    'newsletter_manager' => factory([NewsletterManager::class, 'create'], NewsletterManager::class)
 ];
```

Note this parameter is optional so BC is kept.

This fixes the exception:

> Please add the class to service "config" even if it is constructed by a factory since we might need to add method calls based on compile-time checks.

Symfony documentation:

> When using a factory to create services, the value chosen for the class option has no effect on the resulting service. The actual class name only depends on the object that is returned by the factory. However, the configured class name may be used by compiler passes and therefore should be set to a sensible value.

To keep DX good, the class name parameter can be skipped: the service ID will be used as the class name. This can be used when using class names as service IDs, for example:

```php
return [
    // you can write:
    NewsletterManager::class => factory([NewsletterManager::class, 'create']),
    // instead of:
    NewsletterManager::class => factory([NewsletterManager::class, 'create'], NewsletterManager::class),
];
```

This is based on #29 which refactors tests to cover #28 (which is why there are no tests changes in this commit: tests are already failing because this commit is based on #29).